### PR TITLE
Uninstall typeprof and rbs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   # Disable system libffi for `ffi` gem because it currently doesn't work with Debian Bookworm's FFI
   # See https://github.com/ffi/ffi/issues/1036
   bundle config build.ffi --disable-system-libffi; \
+  # We don't use typeprof or rbs at all so uninstall it as it takes up about 12mbs
+  gem uninstall --all typeprof rbs; \
   # rough smoke test
   ruby --version; \
   gem --version; \


### PR DESCRIPTION
The `rbs` gem takes up about 12mb which is about 5% of the image size.
Just nuke it cause we don't use type signatures at Discourse.

### Reviewer notes

Run `docker run --rm -it  discourse/ruby:3.3.6-bookworm-slim /bin/bash -c "du -h -d 1 /usr/local/lib/ruby/gems/3.3.0/gems | sort -h"` and see 

```
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/abbrev-0.1.2
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/base64-0.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/benchmark-0.3.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/bigdecimal-3.1.5
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/cgi-0.4.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/csv-3.2.8
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/date-3.3.4
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/delegate-0.3.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/did_you_mean-1.6.3
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/digest-3.1.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/drb-2.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/english-0.8.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/error_highlight-0.6.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/etc-1.4.3
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/fcntl-1.1.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/fiddle-1.1.2
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/fileutils-1.7.2
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/find-0.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/forwardable-1.3.3
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/getoptlong-0.2.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/io-console-0.7.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/io-nonblock-0.3.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/io-wait-0.3.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/ipaddr-1.2.6
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/json-2.7.2
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/logger-1.6.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/mutex_m-0.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/net-http-0.4.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/net-protocol-0.2.2
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/nkf-0.1.3
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/observer-0.1.2
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/open-uri-0.4.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/open3-0.2.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/openssl-3.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/optparse-0.4.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/ostruct-0.6.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/pathname-0.3.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/pp-0.5.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/prettyprint-0.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/prism-0.19.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/pstore-0.1.3
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/psych-5.1.2
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/readline-0.0.4
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/reline-0.5.10
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/resolv-0.3.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/resolv-replace-0.1.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/rinda-0.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/ruby2_keywords-0.0.5
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/securerandom-0.3.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/set-1.1.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/shellwords-0.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/singleton-0.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/stringio-3.1.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/strscan-3.0.9
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/syslog-0.1.2
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/tempfile-0.2.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/time-0.3.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/timeout-0.4.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/tmpdir-0.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/tsort-0.2.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/un-0.3.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/uri-0.13.1
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/weakref-0.1.3
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/yaml-0.3.0
4.0K	/usr/local/lib/ruby/gems/3.3.0/gems/zlib-3.1.1
12K	/usr/local/lib/ruby/gems/3.3.0/gems/irb-1.13.1
12K	/usr/local/lib/ruby/gems/3.3.0/gems/syntax_suggest-2.0.1
16K	/usr/local/lib/ruby/gems/3.3.0/gems/bundler-2.5.22
16K	/usr/local/lib/ruby/gems/3.3.0/gems/erb-4.0.3
16K	/usr/local/lib/ruby/gems/3.3.0/gems/rdoc-6.6.3.1
52K	/usr/local/lib/ruby/gems/3.3.0/gems/prime-0.1.2
56K	/usr/local/lib/ruby/gems/3.3.0/gems/net-pop-0.1.2
72K	/usr/local/lib/ruby/gems/3.3.0/gems/net-ftp-0.3.4
76K	/usr/local/lib/ruby/gems/3.3.0/gems/power_assert-2.0.3
80K	/usr/local/lib/ruby/gems/3.3.0/gems/net-smtp-0.4.0.1
116K	/usr/local/lib/ruby/gems/3.3.0/gems/matrix-0.4.2
352K	/usr/local/lib/ruby/gems/3.3.0/gems/racc-1.7.3
396K	/usr/local/lib/ruby/gems/3.3.0/gems/rss-0.3.1
412K	/usr/local/lib/ruby/gems/3.3.0/gems/minitest-5.20.0
420K	/usr/local/lib/ruby/gems/3.3.0/gems/typeprof-0.21.9
452K	/usr/local/lib/ruby/gems/3.3.0/gems/rake-13.1.0
616K	/usr/local/lib/ruby/gems/3.3.0/gems/test-unit-3.6.1
656K	/usr/local/lib/ruby/gems/3.3.0/gems/rexml-3.3.9
704K	/usr/local/lib/ruby/gems/3.3.0/gems/net-imap-0.4.9.1
1.4M	/usr/local/lib/ruby/gems/3.3.0/gems/debug-1.9.2
12M	/usr/local/lib/ruby/gems/3.3.0/gems/rbs-3.4.0
18M	/usr/local/lib/ruby/gems/3.3.0/gems
```