### PR TITLE
Revert "Uninstall typeprof and rbs (#8)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,8 +98,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   # Disable system libffi for `ffi` gem because it currently doesn't work with Debian Bookworm's FFI
   # See https://github.com/ffi/ffi/issues/1036
   bundle config build.ffi --disable-system-libffi; \
-  # We don't use typeprof or rbs at all so uninstall it as it takes up about 12mbs
-  gem uninstall --all typeprof rbs; \
   # rough smoke test
   ruby --version; \
   gem --version; \


### PR DESCRIPTION
This reverts commit 832c4cbc71ae9ad37b7206d83b73e473472a2e30 which was
done to reduce the image size by about 12mb. However, this gain is
bringing us more headaches than benefits so we should just  revert it.
