### PR TITLE
DEV: Install bundler 4.x in addition to the one that comes with ruby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,4 +104,4 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   ruby --version; \
   gem --version; \
   bundle --version; \
-  gem list bundler | grep -q "default:"; 
+  gem list bundler; 

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   # verify we have no "ruby" packages installed
   if dpkg -l | grep -i ruby; then exit 1; fi; \
   [ "$(command -v ruby)" = '/usr/local/bin/ruby' ]; \
+  # Install latest bundler in addition to the one that comes with ruby
+  gem install bundler -v 4.0.11; \
   # Disable system libffi for `ffi` gem because it currently doesn't work with Debian Bookworm's FFI
   # See https://github.com/ffi/ffi/issues/1036
   bundle config build.ffi --disable-system-libffi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,4 +103,5 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   # rough smoke test
   ruby --version; \
   gem --version; \
-  bundle --version
+  bundle --version; \
+  gem list bundler | grep -q "default:"; 


### PR DESCRIPTION
The current ruby version has bundler 2.6.x