### PR TITLE
DEV: Restore GitHub-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ (github.repository_owner == 'discourse' && 'cdck-linux-8-core') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby_version: [3.4.10, 3.3.12, 3.2.11]


### PR DESCRIPTION
Building images take a long time. We don't want to clog up our hosted runners.
